### PR TITLE
Move latest links to GH or packagecloud, remove docker-machine preview

### DIFF
--- a/content/downloads.md
+++ b/content/downloads.md
@@ -11,8 +11,9 @@ Start your Pi with the flashed SD card and enjoy instant Docker awesomeness.
 
 | Description                | Download Link                                                                                            | SHA256 Checksum                                                                      | Published  |
 | :------------------------- | :--------------------------------------------------------------------------------------------------------| :------------------------------------------------------------------------------------| :----------|
-| Version 1.0.0 Blackbeard     | [hypriotos-rpi-v1.0.0.img.zip](https://downloads.hypriot.com/hypriotos-rpi-v1.0.0.img.zip)               | [Checksum](https://downloads.hypriot.com/hypriotos-rpi-v1.0.0.img.zip.sha256)        | 19.08.2016 |
-| Version 0.8.0 Barbossa     | [hypriotos-rpi-v0.8.0.img.zip](https://downloads.hypriot.com/hypriotos-rpi-v0.8.0.img.zip)               | [Checksum](https://downloads.hypriot.com/hypriotos-rpi-v0.8.0.img.zip.sha256)        | 24.05.2016 |
+| Version 1.1.0      | [hypriotos-rpi-v1.1.0.img.zip](https://github.com/hypriot/image-builder-rpi/releases/download/v1.1.0/hypriotos-rpi-v1.1.0.img.zip)               | [Checksum](https://github.com/hypriot/image-builder-rpi/releases/download/v1.1.0/hypriotos-rpi-v1.1.0.img.zip.sha256)        | 12.10.2016 |
+| Version 1.0.0 Blackbeard     | [hypriotos-rpi-v1.0.0.img.zip](https://github.com/hypriot/image-builder-rpi/releases/download/v1.0.0/hypriotos-rpi-v1.0.0.img.zip)               | [Checksum](https://github.com/hypriot/image-builder-rpi/releases/download/v1.0.0/hypriotos-rpi-v1.0.0.img.zip.sha256)        | 19.08.2016 |
+| Version 0.8.0 Barbossa     | [hypriotos-rpi-v0.8.0.img.zip](https://github.com/hypriot/image-builder-rpi/releases/download/v0.8.0/hypriotos-rpi-v0.8.0.img.zip)               | [Checksum](https://github.com/hypriot/image-builder-rpi/releases/download/v0.8.0/hypriotos-rpi-v0.8.0.img.zip.sha256)        | 24.05.2016 |
 | Version 0.7.0 Berry (beta) | [hypriot-rpi-20160306-192317.img.zip](https://downloads.hypriot.com/hypriot-rpi-20160306-192317.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20160306-192317.img.zip.sha256) | 06.03.2016 |
 | Version 0.6.1 Hector       | [hypriot-rpi-20151115-132854.img.zip](https://downloads.hypriot.com/hypriot-rpi-20151115-132854.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20151115-132854.img.zip.sha256) | 15.11.2015 |
 | Version 0.6 Hector         | [hypriot-rpi-20151103-224349.img.zip](https://downloads.hypriot.com/hypriot-rpi-20151103-224349.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20151103-224349.img.zip.sha256) | 03.11.2015 |
@@ -32,50 +33,28 @@ Download and flash this image to your SD card. Boot the RPis and see a real clus
 | Version 0.1.1  | [hypriot_20160121-235123_clusterlab.img.zip](https://downloads.hypriot.com/hypriot_20160121-235123_clusterlab.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot_20160121-235123_clusterlab.img.zip.sha256) | 18.01.2016 |
 | Version 0.1 | [hypriot-rpi-20151128-152209-docker-swarm-cluster.img.zip](https://downloads.hypriot.com/hypriot-rpi-20151128-152209-docker-swarm-cluster.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20151128-152209-docker-swarm-cluster.img.zip.sha25) | 08.12.2015 |
 
-
 ### Hypriot Docker Debian Packages for Raspberry Pi
 These Docker packages are tested with our Docker Hypriot SD card image.  
 Download and then install with `dpkg -i package_name.deb`.
 
-| Description        | Download Link                                                                                                | SHA256 Checksum                                                                      | Published  |
+| Description        | Download Link                                                                                                | Published  |
 | :----------------- | :------------------------------------------------------------------------------------------------------------| :------------------------------------------------------------------------------------| :----------|
-| Docker 1.10.3 | [docker-hypriot_1.10.3-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.10.3-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.10.3-1_armhf.deb.sha256)    | 10.03.2016 |
-| Docker 1.10.2 | [docker-hypriot_1.10.2-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.10.2-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.10.2-1_armhf.deb.sha256)    | 24.02.2016 |
-| Docker 1.10.1 | [docker-hypriot_1.10.1-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.10.1-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.10.1-1_armhf.deb.sha256)    | 12.02.2016 |
-| Docker 1.10.0 | [docker-hypriot_1.10.0-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.10.0-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.10.0-1_armhf.deb.sha256)    | 04.02.2016 |
-| Docker 1.9.1 | [docker-hypriot_1.9.1-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.9.1-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.9.1-1_armhf.deb.sha256)    | 20.11.2015 |
-| Docker 1.9.0-2 | [docker-hypriot_1.9.0-2_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.9.0-2_armhf.deb)               | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.9.0-2_armhf.deb.sha256)        | 08.11.2015 |
-| Docker 1.9.0 | [docker-hypriot_1.9.0-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.9.0-1_armhf.deb)               | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.9.0-1_armhf.deb.sha256)        | 03.11.2015 |
-| Docker 1.8.3 | [docker-hypriot_1.8.3-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.8.3-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.8.3-1_armhf.deb.sha256)    | 13.10.2015 |
-| Docker 1.8.2 | [docker-hypriot_1.8.2-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.8.2-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.8.2-1_armhf.deb.sha256)    | 13.09.2015 |
-| Docker 1.8.1 | [docker-hypriot_1.8.1-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.8.1-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.8.1-1_armhf.deb.sha256)    | 13.08.2015 |
-| Docker 1.8.0 | [docker-hypriot_1.8.0-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.8.0-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.8.0-1_armhf.deb.sha256)    | 11.08.2015 |
-| Docker 1.7.1   | [docker-hypriot_1.7.1-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.7.1-1_armhf.deb)               | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.7.1-1_armhf.deb.sha256)        | 14.07.2015 |
-| Docker 1.7.0-2 | [docker-hypriot_1.7.0-2_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.7.0-2_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.7.0-2_armhf.deb.sha256)    | 30.06.2015 |
-| Docker 1.7.0 | [docker-hypriot_1.7.0-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.7.0-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.7.0-1_armhf.deb.sha256)    | 19.06.2015 |
-| Docker 1.6.2-2 | [docker-hypriot_1.6.2-2_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.6.2-2_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.6.2-2_armhf.deb.sha256)    | 14.06.2015 |
-| Docker 1.6.2   | [docker-hypriot_1.6.2-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.6.2-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.6.2-1_armhf.deb.sha256)    | 15.05.2015 |
-| Docker 1.6.1   | [docker-hypriot_1.6.1-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.6.1-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.6.1-1_armhf.deb.sha256)    | 08.05.2015 |
-| Docker 1.6.0   | [docker-hypriot_1.6.0-1_armhf.deb](https://downloads.hypriot.com/docker-hypriot_1.6.0-1_armhf.deb)       | [Checksum](https://downloads.hypriot.com/docker-hypriot_1.6.0-1_armhf.deb.sha256)    | 16.04.2015 |
-| Docker 1.5.0-7     | [docker-hypriot_1.5.0-7_armhf.deb](httpss://downloads.hypriot.com/docker-hypriot_1.5.0-7_armhf.deb)               | [Checksum](httpss://downloads.hypriot.com/docker-hypriot_1.5.0-7_armhf.deb.sha256)        | 31.03.2015 |
-
-
-### Tech Preview: Docker Machine for using Docker on Raspberry Pi
-Download these precompiled binaries, rename it to `docker-machine` and create a `Docker Machine` on your Raspberry Pi.
-
-```bash
-$ docker-machine create -d hypriot --hypriot-ip-address=11.22.33.44 black-pearl
-$ docker-machine upgrade black-pearl
-```
-
-| Description        | Download Link                                                                                        | SHA256 Checksum                                                                  | Published  |
-| :----------------- | :----------------------------------------------------------------------------------------------------| :--------------------------------------------------------------------------------| :----------|
-| Docker Machine 0.4.1 for Darwin/amd64   | [docker-machine_darwin-amd64_0.4.1](https://downloads.hypriot.com/docker-machine_darwin-amd64_0.4.1) | [Checksum](https://downloads.hypriot.com/docker-machine_darwin-amd64_0.4.1.sha256) | 08.09.2015 |
-| Docker Machine 0.4.1 for Linux/amd64    | [docker-machine_linux-amd64_0.4.1](https://downloads.hypriot.com/docker-machine_linux-amd64_0.4.1) | [Checksum](https://downloads.hypriot.com/docker-machine_linux-amd64_0.4.1.sha256) | 08.09.2015 |
-| Docker Machine 0.4.1 for Linux/arm      | [docker-machine_linux-arm_0.4.1](https://downloads.hypriot.com/docker-machine_linux-arm_0.4.1)  | [Checksum](https://downloads.hypriot.com/docker-machine_linux-arm_0.4.1.sha256) | 08.09.2015 |
-| Docker Machine 0.4.0-dev for Darwin/amd64   | [docker-machine_0.4.0-dev_darwin-amd64](https://downloads.hypriot.com/docker-machine_0.4.0-dev_darwin-amd64) | [Checksum](https://downloads.hypriot.com/docker-machine_0.4.0-dev_darwin-amd64.sha256) | 10.08.2015 |
-| Docker Machine 0.4.0-dev for Linux/amd64    | [docker-machine_0.4.0-dev_linux-amd64](https://downloads.hypriot.com/docker-machine_0.4.0-dev_linux-amd64) | [Checksum](https://downloads.hypriot.com/docker-machine_0.4.0-dev_linux-amd64.sha256) | 10.08.2015 |
-| Docker Machine 0.4.0-dev for Linux/arm      | [docker-machine_0.4.0-dev_linux-arm](https://downloads.hypriot.com/docker-machine_0.4.0-dev_linux-arm)  | [Checksum](https://downloads.hypriot.com/docker-machine_0.4.0-dev_linux-arm.sha256) | 10.08.2015 |
-| Docker Machine 0.3.0-dev for Darwin/amd64   | [docker-machine_0.3.0-dev_darwin-amd64](https://downloads.hypriot.com/docker-machine_0.3.0-dev_darwin-amd64) | [Checksum](https://downloads.hypriot.com/docker-machine_0.3.0-dev_darwin-amd64.sha256) | 25.05.2015 |
-| Docker Machine 0.3.0-dev for Linux/amd64    | [docker-machine_0.3.0-dev_linux-amd64](https://downloads.hypriot.com/docker-machine_0.3.0-dev_linux-amd64) | [Checksum](https://downloads.hypriot.com/docker-machine_0.3.0-dev_linux-amd64.sha256) | 25.05.2015 |
-| Docker Machine 0.3.0-dev for Linux/arm      | [docker-machine_0.3.0-dev_linux-arm](https://downloads.hypriot.com/docker-machine_0.3.0-dev_linux-arm)  | [Checksum](https://downloads.hypriot.com/docker-machine_0.3.0-dev_linux-arm.sha256) | 25.05.2015 |
+| Docker 1.10.3 | [docker-hypriot_1.10.3-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.10.3-1_armhf.deb)       | 10.03.2016 |
+| Docker 1.10.2 | [docker-hypriot_1.10.2-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.10.2-1_armhf.deb)       | 24.02.2016 |
+| Docker 1.10.1 | [docker-hypriot_1.10.1-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.10.1-1_armhf.deb)       | 12.02.2016 |
+| Docker 1.10.0 | [docker-hypriot_1.10.0-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.10.0-1_armhf.deb)       | 04.02.2016 |
+| Docker 1.9.1 | [docker-hypriot_1.9.1-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.9.1-1_armhf.deb)       | 20.11.2015 |
+| Docker 1.9.0-2 | [docker-hypriot_1.9.0-2_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.9.0-2_armhf.deb)       | 08.11.2015 |
+| Docker 1.9.0 | [docker-hypriot_1.9.0-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.9.0-1_armhf.deb)       | 03.11.2015 |
+| Docker 1.8.3 | [docker-hypriot_1.8.3-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.8.3-1_armhf.deb)       | 13.10.2015 |
+| Docker 1.8.2 | [docker-hypriot_1.8.2-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.8.2-1_armhf.deb)       | 13.09.2015 |
+| Docker 1.8.1 | [docker-hypriot_1.8.1-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.8.1-1_armhf.deb)       | 13.08.2015 |
+| Docker 1.8.0 | [docker-hypriot_1.8.0-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.8.0-1_armhf.deb)       | 11.08.2015 |
+| Docker 1.7.1   | [docker-hypriot_1.7.1-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.7.1-1_armhf.deb)       | 14.07.2015 |
+| Docker 1.7.0-2 | [docker-hypriot_1.7.0-2_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.7.0-2_armhf.deb)       | 30.06.2015 |
+| Docker 1.7.0 | [docker-hypriot_1.7.0-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.7.0-1_armhf.deb)       | 19.06.2015 |
+| Docker 1.6.2-2 | [docker-hypriot_1.6.2-2_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.6.2-2_armhf.deb)       | 14.06.2015 |
+| Docker 1.6.2   | [docker-hypriot_1.6.2-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.6.2-1_armhf.deb)       | 15.05.2015 |
+| Docker 1.6.1   | [docker-hypriot_1.6.1-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.6.1-1_armhf.deb)       | 08.05.2015 |
+| Docker 1.6.0   | [docker-hypriot_1.6.0-1_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.6.0-1_armhf.deb)       | 16.04.2015 |
+| Docker 1.5.0-7     | [docker-hypriot_1.5.0-7_armhf.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/wheezy/docker-hypriot_1.5.0-7_armhf.deb)       | 31.03.2015 |

--- a/content/downloads.md
+++ b/content/downloads.md
@@ -14,28 +14,27 @@ Start your Pi with the flashed SD card and enjoy instant Docker awesomeness.
 | Version 1.1.0      | [hypriotos-rpi-v1.1.0.img.zip](https://github.com/hypriot/image-builder-rpi/releases/download/v1.1.0/hypriotos-rpi-v1.1.0.img.zip)               | [Checksum](https://github.com/hypriot/image-builder-rpi/releases/download/v1.1.0/hypriotos-rpi-v1.1.0.img.zip.sha256)        | 12.10.2016 |
 | Version 1.0.0 Blackbeard     | [hypriotos-rpi-v1.0.0.img.zip](https://github.com/hypriot/image-builder-rpi/releases/download/v1.0.0/hypriotos-rpi-v1.0.0.img.zip)               | [Checksum](https://github.com/hypriot/image-builder-rpi/releases/download/v1.0.0/hypriotos-rpi-v1.0.0.img.zip.sha256)        | 19.08.2016 |
 | Version 0.8.0 Barbossa     | [hypriotos-rpi-v0.8.0.img.zip](https://github.com/hypriot/image-builder-rpi/releases/download/v0.8.0/hypriotos-rpi-v0.8.0.img.zip)               | [Checksum](https://github.com/hypriot/image-builder-rpi/releases/download/v0.8.0/hypriotos-rpi-v0.8.0.img.zip.sha256)        | 24.05.2016 |
-| Version 0.7.0 Berry (beta) | [hypriot-rpi-20160306-192317.img.zip](https://downloads.hypriot.com/hypriot-rpi-20160306-192317.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20160306-192317.img.zip.sha256) | 06.03.2016 |
-| Version 0.6.1 Hector       | [hypriot-rpi-20151115-132854.img.zip](https://downloads.hypriot.com/hypriot-rpi-20151115-132854.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20151115-132854.img.zip.sha256) | 15.11.2015 |
-| Version 0.6 Hector         | [hypriot-rpi-20151103-224349.img.zip](https://downloads.hypriot.com/hypriot-rpi-20151103-224349.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20151103-224349.img.zip.sha256) | 03.11.2015 |
-| Version 0.5 Will           | [hypriot-rpi-20151004-132414.img.zip](https://downloads.hypriot.com/hypriot-rpi-20151004-132414.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20151004-132414.img.zip.sha256) | 07.10.2015 |
-| Version 0.5 Will (beta)    | [hypriot-rpi-20150727-151455.img.zip](https://downloads.hypriot.com/hypriot-rpi-20150727-151455.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20150727-151455.img.zip.sha256) | 27.07.2015 |
-| Version 0.4 Elizabeth      | [hypriot-rpi-20150416-201537.img.zip](https://downloads.hypriot.com/hypriot-rpi-20150416-201537.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20150416-201537.img.zip.sha256) | 16.04.2015 |
-| Version 0.3 Jack           | [hypriot-rpi-20150329-140334.img.zip](https://downloads.hypriot.com/hypriot-rpi-20150329-140334.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20150329-140334.img.zip.sha256) | 30.03.2015 |
-| Version 0.2                | [hypriot-rpi-20150301-140537.img.zip](https://downloads.hypriot.com/hypriot-rpi-20150301-140537.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20150301-140537.img.zip.sha256) | 04.03.2015 |
-| Version 0.1                | [hypriot-rpi-20150208-015447.zip](https://downloads.hypriot.com/hypriot-rpi-20150208-015447.zip)         |                                                                                      | 08.02.2015 |
+| Version 0.7.0 Berry (beta) | hypriot-rpi-20160306-192317.img.zip |  | 06.03.2016 |
+| Version 0.6.1 Hector       | hypriot-rpi-20151115-132854.img.zip |  | 15.11.2015 |
+| Version 0.6 Hector         | hypriot-rpi-20151103-224349.img.zip |  | 03.11.2015 |
+| Version 0.5 Will           | hypriot-rpi-20151004-132414.img.zip |  | 07.10.2015 |
+| Version 0.5 Will (beta)    | hypriot-rpi-20150727-151455.img.zip |  | 27.07.2015 |
+| Version 0.4 Elizabeth      | hypriot-rpi-20150416-201537.img.zip |  | 16.04.2015 |
+| Version 0.3 Jack           | hypriot-rpi-20150329-140334.img.zip |  | 30.03.2015 |
+| Version 0.2                | hypriot-rpi-20150301-140537.img.zip |  | 04.03.2015 |
+| Version 0.1                | hypriot-rpi-20150208-015447.zip     |  | 08.02.2015 |
 
 
 ### Hypriot Cluster Lab
-Download and flash this image to your SD card. Boot the RPis and see a real cluster up and running!  
+Download Hypriot Cluster Lab packages from packagecloud.io.
 
-| Description                                                                                                                            | Download Link                                                                                                                                     | SHA256 Checksum                                                                                         | Published  |
-|:-------------------------------------------------------------------------------------------------------------------------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------|:------------|
-| Version 0.1.1  | [hypriot_20160121-235123_clusterlab.img.zip](https://downloads.hypriot.com/hypriot_20160121-235123_clusterlab.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot_20160121-235123_clusterlab.img.zip.sha256) | 18.01.2016 |
-| Version 0.1 | [hypriot-rpi-20151128-152209-docker-swarm-cluster.img.zip](https://downloads.hypriot.com/hypriot-rpi-20151128-152209-docker-swarm-cluster.img.zip) | [Checksum](https://downloads.hypriot.com/hypriot-rpi-20151128-152209-docker-swarm-cluster.img.zip.sha25) | 08.12.2015 |
+| Description        | Download Link                                                                                                | Published  |
+| :----------------- | :------------------------------------------------------------------------------------------------------------| :------------------------------------------------------------------------------------| :----------|
+| Hypriot Cluster Lab 0.2.14 | [hypriot-cluster-lab_0.2.14-1_all.deb](https://packagecloud.io/Hypriot/Schatzkiste/packages/debian/jessie/hypriot-cluster-lab_0.2.14-1_all.deb)       | 08.06.2016 |
 
 ### Hypriot Docker Debian Packages for Raspberry Pi
 These Docker packages are tested with our Docker Hypriot SD card image.  
-Download and then install with `dpkg -i package_name.deb`.
+Download them from packagecloud.io.
 
 | Description        | Download Link                                                                                                | Published  |
 | :----------------- | :------------------------------------------------------------------------------------------------------------| :------------------------------------------------------------------------------------| :----------|

--- a/content/post/deploy-swarm-on-chip-with-docker-machine.md
+++ b/content/post/deploy-swarm-on-chip-with-docker-machine.md
@@ -243,7 +243,7 @@ Here you can see that using [HypriotOS for RPi](https://github.com/hypriot/image
 
 Flash the SD card, and power up the Raspberry Pi Zero.
 ```
-flash -n swarm-raspi01 -s "WLAN-R46VFR" -p "************" https://downloads.hypriot.com/hypriotos-rpi-v1.0.0.img.zip
+flash -n swarm-raspi01 -s "WLAN-R46VFR" -p "************" https://github.com/hypriot/image-builder-rpi/releases/download/v1.0.0/hypriotos-rpi-v1.0.0.img.zip
 ```
 
 Determine the IP address of the Pi Zero.

--- a/content/post/microservices-bliss-with-docker-and-traefik.md
+++ b/content/post/microservices-bliss-with-docker-and-traefik.md
@@ -56,12 +56,12 @@ $ cd flash/Darwin
 
 With the flash tool ready we now can prepare the SD card for our __leader node__:
 ```
-$ ./flash --hostname cl-leader https://downloads.hypriot.com/hypriotos-rpi-v0.8.0.img.zip
+$ ./flash --hostname cl-leader https://github.com/hypriot/image-builder-rpi/releases/download/v0.8.0/hypriotos-rpi-v0.8.0.img.zip
 ```
 
 Repeat the process for the __follower nodes__:
 ```
-$ for i in {1..4} do; ./flash --hostname cl-follower${i} https://downloads.hypriot.com/hypriotos-rpi-v0.8.0.img.zip; done
+$ for i in {1..4} do; ./flash --hostname cl-follower${i} https://github.com/hypriot/image-builder-rpi/releases/download/v0.8.0/hypriotos-rpi-v0.8.0.img.zip; done
 ```
 
 While the SD cards for the follower nodes are still being flashed you can already start the leader node.

--- a/content/post/releasing-HypriotOS-1-0.md
+++ b/content/post/releasing-HypriotOS-1-0.md
@@ -52,7 +52,7 @@ Please see all details in the [release notes](https://github.com/hypriot/image-b
 ## Quick start
 **Download our [flash tool](https://github.com/hypriot/flash) and run**
 ```
-flash https://downloads.hypriot.com/hypriotos-rpi-v1.0.0.img.zip
+flash https://github.com/hypriot/image-builder-rpi/releases/download/v1.0.0/hypriotos-rpi-v1.0.0.img.zip
 ```
 
 **Afterwards, put the SD card into the Raspberry Pi and power it. That's all to get HypriotOS up and running!**
@@ -68,7 +68,7 @@ with password "hypriot".
 
 If you want the Raspberry Pi to connect directly to your Wi-Fi after boot, change the hostname of the Raspberry Pi and more, edit `/boot/device-init.yaml` of the SD card and have a look at the [documentation of device-init](https://github.com/hypriot/device-init). Alternatively, checkout the parameters of the [Hypriot flash tool](https://github.com/hypriot/flash) that also allows you to define configurations. Really, it's just so damn easy:
 ```
-flash -n myHOSTNAME -s mySSID -p myWIFIPASSWORD https://downloads.hypriot.com/hypriotos-rpi-v1.0.0.img.zip
+flash -n myHOSTNAME -s mySSID -p myWIFIPASSWORD https://github.com/hypriot/image-builder-rpi/releases/download/v1.0.0/hypriotos-rpi-v1.0.0.img.zip
 ```
 
 


### PR DESCRIPTION
Added HypriotOS 1.1.0 download link, moved 1.0.0 and 0.8.0 to GH releases.
Moved some other deb downloads to packagecloud.
Removed docker-machine technical preview.
