### PR TITLE
Remove all markdown hyperlinks to downloads.hypriot.com

### DIFF
--- a/content/post/docker-1-6-is-finally-released-into-the-wild.md
+++ b/content/post/docker-1-6-is-finally-released-into-the-wild.md
@@ -17,8 +17,7 @@ Use it to get the best Docker experience available for the Raspberry Pi. It is r
 
 The image can be downloaded here:
 
-[Docker-Pi Image](http://downloads.hypriot.com/hypriot-rpi-20150416-201537.img.zip) (~369MB)  
-[SHA256 checksum](http://downloads.hypriot.com/hypriot-rpi-20150416-201537.img.zip.sha256)
+Docker-Pi Image (hypriot-rpi-20150416-201537.img.zip) (~369MB)  
 
 For everybody else use our Docker Debian package at your own peril... :)
 
@@ -41,8 +40,7 @@ Read some more details on the official Docker blog
 [DOCKER 1.6: ENGINE & ORCHESTRATION UPDATES, REGISTRY 2.0, & WINDOWS CLIENT PREVIEW](https://blog.docker.com/2015/04/docker-release-1-6/)
 
 ## Get it while it is still hot
-[docker-hypriot_1.6.0-1_armhf.deb](http://downloads.hypriot.com/docker-hypriot_1.6.0-1_armhf.deb) (~ 6MB)  
-[SHA256 checksum](http://downloads.hypriot.com/docker-hypriot_1.6.0-1_armhf.deb.sha256)
+docker-hypriot_1.6.0-1_armhf.deb
 
 All you have to do is to start up your Pi with our SD card image, download the prepared Docker package and install it with dpkg.
 

--- a/content/post/docker-1-dot-6-release-candidate-ready-for-arm.md
+++ b/content/post/docker-1-dot-6-release-candidate-ready-for-arm.md
@@ -27,8 +27,7 @@ Find out more details in the [changelog](https://github.com/docker/docker/blob/v
 The only prerequisite to get started is that you are using our Hypriot SD card image for the Rasperry Pi. We published a new version just yesterday and you can the blog post about it here: [HypriotOS: Back Again and Better then Ever](http://blog.hypriot.com/post/hypriotos-back-again-with-docker-on-arm).
 
 ### Get it while it is still hot
-[docker-hypriot_1.6.0-rc2-1_armhf.deb](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc2-1_armhf.deb) (~ 6MB)  
-[SHA256 checksum](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc2-1_armhf.deb.sha256)
+docker-hypriot_1.6.0-rc2-1_armhf.deb
 
 All you have to do is to start up your Pi with our SD card image, download the prepared Docker package and install it with dpkg.
 
@@ -51,27 +50,22 @@ Have fun.
 ### Update 01.04.2015: Get Docker 1.6.0 RC3
 Two hours ago the Docker team released another release candidate, so we've cooked it for you.
 
-[docker-hypriot_1.6.0-rc3-1_armhf.deb](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc3-1_armhf.deb) (~ 6MB)  
-[SHA256 checksum](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc3-1_armhf.deb.sha256)
+docker-hypriot_1.6.0-rc3-1_armhf.deb
 
 ### Update 03.04.2015: Get Docker 1.6.0 RC4
 Well, this time it is already 11 hours since it was published. But still here is the lastest and greatest.
 
-[docker-hypriot_1.6.0-rc4-1_armhf.deb](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc4-1_armhf.deb) (~ 6MB)  
-[SHA256 checksum](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc4-1_armhf.deb.sha256)
+docker-hypriot_1.6.0-rc4-1_armhf.deb
 
 ### Update 12.04.2015: Get Docker 1.6.0 RC5
-[docker-hypriot_1.6.0-rc5-1_armhf.deb](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc5-1_armhf.deb) (~ 6MB)  
-[SHA256 checksum](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc5-1_armhf.deb.sha256)
+docker-hypriot_1.6.0-rc5-1_armhf.deb
 
 ### Update 14.04.2015: Get Docker 1.6.0 RC6
 Maybe this could be the last release candidate before a final 1.6.0 release.
 
-[docker-hypriot_1.6.0-rc6-1_armhf.deb](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc6-1_armhf.deb) (~ 6MB)  
-[SHA256 checksum](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc6-1_armhf.deb.sha256)
+docker-hypriot_1.6.0-rc6-1_armhf.deb
 
 ### Update 15.04.2015: Get Docker 1.6.0 RC7
 OK, here is the next 1.6.0 release candidate.
 
-[docker-hypriot_1.6.0-rc7-1_armhf.deb](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc7-1_armhf.deb) (~ 6MB)  
-[SHA256 checksum](http://downloads.hypriot.com/docker-hypriot_1.6.0-rc7-1_armhf.deb.sha256)
+docker-hypriot_1.6.0-rc7-1_armhf.deb

--- a/content/post/get-your-all-in-one-docker-playground-now-hypriotos-reloaded.md
+++ b/content/post/get-your-all-in-one-docker-playground-now-hypriotos-reloaded.md
@@ -76,8 +76,7 @@ Rest assured that we still have some more major improvements in our release pipe
 
 
 ### Download: Get it while it is still hot
-[hypriot-rpi-20151004-132414.img.zip](http://downloads.hypriot.com/hypriot-rpi-20151004-132414.img.zip) (~ 438 MB)
-[SHA256 checksum](http://downloads.hypriot.com/hypriot-rpi-20151004-132414.img.zip.sha256)
+hypriot-rpi-20151004-132414.img.zip
 
 
 Check out our [Getting-Started-Guide](http://blog.hypriot.com/getting-started-with-docker-on-your-arm-device/) on how to get this SD card image running on our Pi.

--- a/content/post/heavily-armed-after-major-upgrade-raspberry-pi-with-docker-1-dot-5-0.md
+++ b/content/post/heavily-armed-after-major-upgrade-raspberry-pi-with-docker-1-dot-5-0.md
@@ -60,8 +60,7 @@ Besides that we kept some features which were already awesome
 ## Download
 The image can be downloaded here:
 
-[Docker-Pi Image](http://downloads.hypriot.com/hypriot-rpi-20150301-140537.img.zip) (~347MB)  
-[SHA256 checksum](http://downloads.hypriot.com/hypriot-rpi-20150301-140537.img.zip.sha256)
+Docker-Pi Image (hypriot-rpi-20150301-140537.img.zip) (~347MB)  
 
 __Update (30.03.2015):__ We have published a more [recent version of our SD card image](http://blog.hypriot.com/post/hypriotos-back-again-with-docker-on-arm).
 

--- a/content/post/hypriotos-back-again-with-docker-on-arm.md
+++ b/content/post/hypriotos-back-again-with-docker-on-arm.md
@@ -147,8 +147,7 @@ Windows users need to install [iTunes](https://www.apple.com/de/itunes/download/
 ## Download
 The new image can be downloaded here:
 
-[Docker-Pi Image](http://downloads.hypriot.com/hypriot-rpi-20150329-140334.img.zip) (~367MB)  
-[SHA256 checksum](http://downloads.hypriot.com/hypriot-rpi-20150329-140334.img.zip.sha256)
+Docker-Pi Image (hypriot-rpi-20150329-140334.img.zip) (~367MB)  
 
 ## How to get started
 Download our SD card image and flash it on your own SD card. [Here](http://computers.tutsplus.com/articles/how-to-flash-an-sd-card-for-raspberry-pi--mac-53600) is a short guide on how to do this for Mac, Windows and Linux users. Afterwards insert the SD card in your Raspberry Pi and wait while it boots. The first time will take a little longer as it resizes the file system to its maximum and reboots again.

--- a/content/post/introducing-hypriot-cluster-lab-docker-clustering-as-easy-as-it-gets.md
+++ b/content/post/introducing-hypriot-cluster-lab-docker-clustering-as-easy-as-it-gets.md
@@ -66,7 +66,7 @@ Additionally, the switch should not filter IEEE 802.1Q VLAN flags out of network
 
 ### Download. Flash. Boot. Enjoy!
 
-__1.__ __Download__ the [Hypriot Cluster Lab SD card image](http://downloads.hypriot.com/hypriot_20160121-235123_clusterlab.img.zip).
+__1.__ __Download__ the Hypriot Cluster Lab SD card image (hypriot_20160121-235123_clusterlab.img.zip).
 
 __2.__ Flash the image to your SD cards your way or use [our funky flash script](https://github.com/hypriot/flash) which makes flashing the SD cards so much easier.  
 

--- a/content/post/just-in-time-for-DockerCon-EU-a-shipload-of-new-Docker-ARM-goodies.md
+++ b/content/post/just-in-time-for-DockerCon-EU-a-shipload-of-new-Docker-ARM-goodies.md
@@ -33,7 +33,7 @@ Besides that we enabled some missing cgroup kernel settings for better Docker su
 We also added a default `/boot/config.txt`, which for instance allows for a better out-of-the-box HDMI display experience (`hdmi_force_hotplug=1`).
 
 There is no easier way to get started with Docker on ARM.
-Just give it a try: Download our [latest image](http://downloads.hypriot.com/hypriot-rpi-20151115-132854.img.zip) and get started in less than 5 minutes.
+Just give it a try: Download our latest image (hypriot-rpi-20151115-132854.img.zip) and get started in less than 5 minutes.
 
 
 ### Detailed Features of HypriotOS "Hector"
@@ -53,8 +53,7 @@ Just give it a try: Download our [latest image](http://downloads.hypriot.com/hyp
 
 
 ### Download: Get it while it is still hot
-[hypriot-rpi-20151115-132854.img.zip](http://downloads.hypriot.com/hypriot-rpi-20151115-132854.img.zip) (~ 438 MB)
-[SHA256 checksum](hypriot-rpi-20151115-132854.img.zip.sha256)
+hypriot-rpi-20151115-132854.img.zip (hypriot-rpi-20151115-132854.img.zip) (~ 438 MB)
 
 Check out our [Getting-Started-Guide](http://blog.hypriot.com/getting-started-with-docker-on-your-arm-device/) on how to get this SD card image running on your Raspberry Pi.
 

--- a/content/post/kick-ass-raspberry-pi-2-having-a-forbidden-love-affair-with-docker-1-dot-4-1.md
+++ b/content/post/kick-ass-raspberry-pi-2-having-a-forbidden-love-affair-with-docker-1-dot-4-1.md
@@ -62,7 +62,7 @@ Our first tests went really well and we could do all the basic Docker stuff with
 
 We really would like to see how our image works for others and that is why you can download it here:
 
-[Docker-Pi-Image](http://downloads.hypriot.com/hypriot-rpi-20150208-015447.zip) (~400MB)
+ Docker-Pi-Image (hypriot-rpi-20150208-015447.zip) (~400MB)
 
 __Update (30.03.2015):__ We have published a more [recent version of our SD card image](http://blog.hypriot.com/post/hypriotos-back-again-with-docker-on-arm).
 

--- a/content/post/moving-docker-from-wheezy-to-jessie.md
+++ b/content/post/moving-docker-from-wheezy-to-jessie.md
@@ -26,12 +26,11 @@ On top of that we added all the battle-tested ingredients of our previous Get-Do
 - support for __Avahi__ (aka Apple Bonjour)
 - support for __Open vSwitch__
 
-We consider this new version of our SD card image still as __beta quality__. 
+We consider this new version of our SD card image still as __beta quality__.
 During the next two weeks we want to improve it step by step and gather feedback to make it a great out-of-the-box experience for our users.
 
 ### Get it while it is still hot
-[hypriot-rpi-20150727-151455.img.zip](http://downloads.hypriot.com/hypriot-rpi-20150727-151455.img.zip) (~ 424 MB)  
-[SHA256 checksum](http://downloads.hypriot.com/hypriot-rpi-20150727-151455.img.zip.sha256)
+ hypriot-rpi-20150727-151455.img.zip (~ 424 MB)  
 
 Check out our [Getting-Started-Guide](http://blog.hypriot.com/getting-started-with-docker-on-your-arm-device/) on how to get this SD card image running on our Pi.
 

--- a/content/post/rc1-jessie-with-brand-new-kernel-and-docker.md
+++ b/content/post/rc1-jessie-with-brand-new-kernel-and-docker.md
@@ -35,8 +35,7 @@ On top of [Jessie](http://arstechnica.com/information-technology/2015/05/debian-
 During the next two weeks we want to improve the SD card image and gather more feedback to make it a great out-of-the-box experience for our users.
 
 ### Get it while it is still hot
-[hypriot-rpi-20150909-070022.img.zip](http://downloads.hypriot.com/hypriot-rpi-20150909-070022.img.zip) (~ 398 MB)
-[SHA256 checksum](http://downloads.hypriot.com/hypriot-rpi-20150909-070022.img.zip.sha256)
+hypriot-rpi-20150909-070022.img.zip (~ 398 MB)
 
 Check out our [Getting-Started-Guide](http://blog.hypriot.com/getting-started-with-docker-on-your-arm-device/) on how to get this SD card image running on our Pi.
 

--- a/content/post/rc2-jessie-with-brand-new-kernel-and-docker-and-display-support.md
+++ b/content/post/rc2-jessie-with-brand-new-kernel-and-docker-and-display-support.md
@@ -46,8 +46,7 @@ On top of [Jessie](http://arstechnica.com/information-technology/2015/05/debian-
 During the next two weeks we want to improve the SD card image and gather more feedback to make it a great out-of-the-box experience for our users.
 
 ### Get it while it is still hot
-[hypriot-rpi-20150928-174643.img.zip](http://downloads.hypriot.com/hypriot-rpi-20150928-174643.img.zip) (~ 438 MB)
-[SHA256 checksum](http://downloads.hypriot.com/hypriot-rpi-20150928-174643.img.zip.sha256)
+hypriot-rpi-20150928-174643.img.zip (~ 438 MB)
 
 Check out our [Getting-Started-Guide](http://blog.hypriot.com/getting-started-with-docker-on-your-arm-device/) on how to get this SD card image running on our Pi.
 


### PR DESCRIPTION
Remove all remaining hyperlinks to downloads.hypriot.com.
The blog post texts that use these links stay untouched.
