### PR TITLE
Set watch=false to disable http livereload links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ baseurl = "https://blog.hypriot.com/"
 languageCode = "en-us"
 title = "Docker Pirates ARMed with explosive stuff"
 theme = "hyde"
-watch = "true"
+watch = "false"
 
 [params]
   Description = "Roaming the seven seas in search for golden container plunder."


### PR DESCRIPTION
The live blog.hypriot.com still has some http links to /livereload.js.
This is caused by the `watch = "true"` in `config.toml`.
This PR disables this feature. You should  use `hugo server --watch=true -D &` locally.
